### PR TITLE
update footer 2021 link

### DIFF
--- a/404.html
+++ b/404.html
@@ -196,7 +196,7 @@ if you can’t find it, <a href="contact/">ask about it</a>.</p>
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -218,7 +218,7 @@ if you can’t find it, <a href="contact/">ask about it</a>.</p>
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-cluster2021 is a source directory of gekyll.
+cluster2022 is a source directory of gekyll.
 $ bundle exec jekyll b
 generates html files in _site directory.
 pages/*.md files are source files of each html files.

--- a/assets/xslt/rss.xslt
+++ b/assets/xslt/rss.xslt
@@ -508,7 +508,7 @@
             
               
                 <li class="ieee-2023" >
-                  <a href="https://clustercomp.org/2021/" target="_blank"  title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+                  <a href="https://clustercomp.org/2022/" target="_blank"  title="IEEE Cluster 2022">IEEE Cluster 2022</a>
                 </li>
             
               

--- a/authors/index.html
+++ b/authors/index.html
@@ -204,7 +204,7 @@ workshop organizers) + additional pages for a fee</li>
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -226,7 +226,7 @@ workshop organizers) + additional pages for a fee</li>
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/committees/index.html
+++ b/committees/index.html
@@ -357,7 +357,7 @@ Frank Mueller, North Carolina State University, USA</p>
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -379,7 +379,7 @@ Frank Mueller, North Carolina State University, USA</p>
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/contact/index.html
+++ b/contact/index.html
@@ -186,7 +186,7 @@
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -208,7 +208,7 @@
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/double_blind.html
+++ b/double_blind.html
@@ -239,7 +239,7 @@
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -261,7 +261,7 @@
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/humans.txt
+++ b/humans.txt
@@ -16,7 +16,7 @@ Theme: http://phlow.github.io/feeling-responsive/
 
 /* SITE */
 
-Last Updated: 2021/09/20
+Last Updated: 2022/09/20
 Standards: HTML5, CSS3
 Software: Sublime Text, Chrome, Jekyll, Git, Imageoptim, JPEGMini, Gulp.js, Sass
 Components: Foundation Framework, Modernizr, jQuery, Backstretch.js, Reveal

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@ discuss recent advances and trends in, but not limited to:</p>
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -224,7 +224,7 @@ discuss recent advances and trends in, but not limited to:</p>
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/keynotes/index.html
+++ b/keynotes/index.html
@@ -173,7 +173,7 @@
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -195,7 +195,7 @@
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/mentoring/index.html
+++ b/mentoring/index.html
@@ -240,7 +240,7 @@ considered for attendance support.
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -262,7 +262,7 @@ considered for attendance support.
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/news/index.html
+++ b/news/index.html
@@ -180,7 +180,7 @@
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -202,7 +202,7 @@
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/papers/index.html
+++ b/papers/index.html
@@ -279,7 +279,7 @@
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -301,7 +301,7 @@
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/policy.html
+++ b/policy.html
@@ -216,7 +216,7 @@ eventconduct@ieee.org.</p>
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -238,7 +238,7 @@ eventconduct@ieee.org.</p>
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/posters/index.html
+++ b/posters/index.html
@@ -209,7 +209,7 @@
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -231,7 +231,7 @@
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/program/index.html
+++ b/program/index.html
@@ -172,7 +172,7 @@
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -194,7 +194,7 @@
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/registration/index.html
+++ b/registration/index.html
@@ -151,9 +151,9 @@
 
 [Register HERE](https://cvent.me/vwmKno)
 
-**Early registration deadline:** August 27, 2021 (11:59pm Pacific)
+**Early registration deadline:** August 27, 2022 (11:59pm Pacific)
 
-**Author registration deadline:** August 16, 2021 (11:59pm Pacific)
+**Author registration deadline:** August 16, 2022 (11:59pm Pacific)
 
 At least one author of each accepted paper must register as an author at
 the full registration rate (*see* Author Registration below).
@@ -161,7 +161,7 @@ the full registration rate (*see* Author Registration below).
 Each Author Registration can be applied to only one paper.
 
 **Cancellation Policy:** All registrations are final. <u>Registration
-for IEEE Cluster 2021 is non-refundable.</u>
+for IEEE Cluster 2022 is non-refundable.</u>
 
 Any problems? Please send a message to
 [registration+CLUSTER@computer.org](registration+CLUSTER@computer.org)
@@ -211,7 +211,7 @@ Any problems? Please send a message to
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -233,7 +233,7 @@ Any problems? Please send a message to
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -150,7 +150,7 @@ during the conference.</em></p>
 <p>The IEEE Cluster Conference serves as a major international forum for
 presenting and sharing recent accomplishments and technological
 developments in the field of cluster computing as well as the use of
-cluster systems for scientific and commercial applications. Cluster 2021
+cluster systems for scientific and commercial applications. Cluster 2022
 involves participants (researchers, developers, and users) from
 academia, industry, laboratories, and commerce, coming together to
 discuss recent advances and trends in, but not limited to:</p>
@@ -180,7 +180,7 @@ provided, company banner if provided. Vendor table top displays will
 be located in prime space near the conference halls.</li>
   <li>Symposium Advertisements: listed in Agenda, listed on Website,
 opportunity to share promotional items at Commitment desk.</li>
-  <li>Includes attendance to Cluster 2021 for one person.</li>
+  <li>Includes attendance to Cluster 2022 for one person.</li>
 </ul>
 
 <p><strong>Silver</strong> - “Breakfast” (Early Commitment: €5,500, Late Commitment: €6,500).</p>
@@ -199,7 +199,7 @@ function.</li>
   <li>Table Top Display and Symposium Advertisement as above.</li>
   <li>“Lunch supported by…”: display of company banner if provided,
 display of company logo on signage for supported function.</li>
-  <li>Includes attendance to Cluster2021 for three persons.</li>
+  <li>Includes attendance to Cluster2022 for three persons.</li>
 </ul>
 
 <p><strong>Platinum</strong> - “Evening Event” (Early Commitment: €15,000, Late Commitment: €18,000).</p>
@@ -267,7 +267,7 @@ the order of contact, when the conference registration opens in June
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -289,7 +289,7 @@ the order of contact, when the conference registration opens in June
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/tutorials/index.html
+++ b/tutorials/index.html
@@ -195,7 +195,7 @@
 
 <p>Please note that the number of presenters is limited to 2 for a half-day tutorial and to 3 for full day tutorial.</p>
 
-<p>A single pdf file with all the material described above should be submitted to the Cluster 2021 conference<a href="https://clustercomp.org/submit"> https://clustercomp.org/submit</a> under the tutorial track. Acceptance of a proposed tutorial will be made based on the quality, content, and organization, and its relationship to key topic areas when compared with other submissions.</p>
+<p>A single pdf file with all the material described above should be submitted to the Cluster 2022 conference<a href="https://clustercomp.org/submit"> https://clustercomp.org/submit</a> under the tutorial track. Acceptance of a proposed tutorial will be made based on the quality, content, and organization, and its relationship to key topic areas when compared with other submissions.</p>
 
 <p>Tutorial Proposal Submission:<a href="https://ssl.linklings.net/conferences/ieeecluster/"> https://ssl.linklings.net/conferences/ieeecluster/</a></p>
 
@@ -243,7 +243,7 @@
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -265,7 +265,7 @@
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2021</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/venue/index.html
+++ b/venue/index.html
@@ -240,7 +240,7 @@
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -262,7 +262,7 @@
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2022</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"

--- a/workshops/index.html
+++ b/workshops/index.html
@@ -250,7 +250,7 @@ stack. All workshops will be held on October 31st, 2023.</p>
           <h5 class="shadow-black">Services</h5>
           <ul class="no-bullet shadow-black">
             <li>
-              <a href="https://clustercomp.org/2021" title=""></a>
+              <a href="https://clustercomp.org/2022" title=""></a>
             </li>
             <li>
               <a href="contact/" title="Contact">Contact</a>
@@ -272,7 +272,7 @@ stack. All workshops will be held on October 31st, 2023.</p>
               <a href="http://www.ieee.org/" target="_blank" title="IEEE Home">IEEE Home</a>
             </li>
             <li class="ieee-2021">
-              <a href="https://clustercomp.org/2021/" target="_blank" title="IEEE Cluster 2021">IEEE Cluster 2021</a>
+              <a href="https://clustercomp.org/2022/" target="_blank" title="IEEE Cluster 2022">IEEE Cluster 2021</a>
             </li>
             <li class="ieee-committeee">
               <a href="https://clustercomp.org/committee/committees" target="_blank"


### PR DESCRIPTION
the footer contains links to 2021 instead of 2022. Updating the link for issue #9 